### PR TITLE
v3 문제 풀이

### DIFF
--- a/src/main/java/com/ll/framework/ioc/ApplicationContext.java
+++ b/src/main/java/com/ll/framework/ioc/ApplicationContext.java
@@ -1,15 +1,140 @@
 package com.ll.framework.ioc;
 
+import com.ll.framework.ioc.annotations.Bean;
+import com.ll.framework.ioc.annotations.Configuration;
+import com.ll.framework.ioc.annotations.Repository;
+import com.ll.framework.ioc.annotations.Service;
+import org.reflections.Reflections;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.*;
+import java.util.stream.Collectors;
+
 public class ApplicationContext {
+    // 모든 빈 인스턴스를 저장하는 Map (싱글톤 보장)
+    private final Map<String, Object> beans = new HashMap<>();
+    private final Reflections reflections;
 
     public ApplicationContext(String basePackage) {
-
+        // Reflections 라이브러리를 사용하여 basePackage 하위 클래스들을 스캔
+        this.reflections = new Reflections(basePackage);
     }
 
     public void init() {
+        // 1. @Configuration 클래스 처리
+        Set<Class<?>> configClasses = reflections.getTypesAnnotatedWith(Configuration.class);
+        for (Class<?> configClass : configClasses) {
+            try {
+                // 설정 클래스(@Configuration) 인스턴스 생성
+                Object configInstance = createBeanInstance(configClass);
+
+                // @Bean 메서드 실행하여 빈 등록
+                for (Method method : configClass.getDeclaredMethods()) {
+                    if (method.isAnnotationPresent(Bean.class)) {
+                        String beanName = method.getName(); // 메서드 이름 = 빈 이름
+                        if (!beans.containsKey(beanName)) {
+                            // @Bean 메서드 호출로 빈 생성
+                            Object bean = createBeanFromMethod(configInstance, method);
+                            beans.put(beanName, bean);
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                throw new RuntimeException("Configuration 처리 중 오류: " + configClass.getName(), e);
+            }
+        }
+
+        // 2. @Service, @Repository 클래스 처리
+        // @Service 클래스 수집
+        List<Class<?>> beanClasses = reflections.getTypesAnnotatedWith(Service.class)
+                .stream().collect(Collectors.toList());
+        // @Repository 클래스 추가
+        beanClasses.addAll(reflections.getTypesAnnotatedWith(Repository.class));
+
+        // 수집된 클래스들 빈으로 생성
+        for (Class<?> beanClass : beanClasses) {
+            String beanName = getBeanName(beanClass);
+            createBean(beanClass, beanName);
+        }
     }
 
+    /**
+     * @Bean 메서드를 실행하여 빈을 생성하는 메서드
+     */
+    private Object createBeanFromMethod(Object configInstance, Method method) throws Exception {
+        Class<?>[] paramTypes = method.getParameterTypes();
+        Object[] dependencies = new Object[paramTypes.length];
+
+        // 메서드 파라미터(의존성) 처리
+        for (int i = 0; i < paramTypes.length; i++) {
+            String depName = getBeanName(paramTypes[i]);
+            // 의존 빈이 없으면 먼저 생성
+            if (!beans.containsKey(depName)) {
+                createBean(paramTypes[i], depName);
+            }
+            dependencies[i] = beans.get(depName);
+        }
+        // @Bean 메서드 호출하여 빈 인스턴스 반환
+        return method.invoke(configInstance, dependencies);
+    }
+
+    /**
+     * 주어진 클래스 타입과 이름으로 빈을 생성하여 등록
+     */
+    private void createBean(Class<?> beanClass, String beanName) {
+        // 이미 존재하는 빈이면 생성하지 않음 (싱글톤 보장)
+        if (beans.containsKey(beanName)) return;
+
+        try {
+            Object beanInstance = createBeanInstance(beanClass);
+            beans.put(beanName, beanInstance);
+        } catch (Exception e) {
+            throw new RuntimeException("빈 생성 중 오류: " + beanClass.getName(), e);
+        }
+    }
+
+    /**
+     * 생성자를 통해 빈 인스턴스 생성
+     * 생성자 파라미터는 자동으로 의존성 주입
+     */
+    private Object createBeanInstance(Class<?> beanClass) throws Exception {
+        Constructor<?>[] constructors = beanClass.getConstructors();
+        if (constructors.length != 1) {
+            throw new IllegalStateException("빈은 하나의 public 생성자만 가져야 합니다.");
+        }
+        Constructor<?> constructor = constructors[0];
+
+        // 생성자 파라미터 타입 추출
+        Class<?>[] parameterTypes = constructor.getParameterTypes();
+        Object[] dependencies = new Object[parameterTypes.length];
+
+        // 필요한 의존성을 먼저 생성 후 주입
+        for (int i = 0; i < parameterTypes.length; i++) {
+            String dependencyBeanName = getBeanName(parameterTypes[i]);
+            if (!beans.containsKey(dependencyBeanName)) {
+                createBean(parameterTypes[i], dependencyBeanName);
+            }
+            dependencies[i] = beans.get(dependencyBeanName);
+        }
+
+        // 최종 인스턴스 생성
+        return constructor.newInstance(dependencies);
+    }
+
+    /**
+     * 클래스명에서 첫 글자만 소문자로 변환하여 빈 이름 생성
+     * 예: TestPostService -> testPostService
+     */
+    private String getBeanName(Class<?> beanClass) {
+        String className = beanClass.getSimpleName();
+        return Character.toLowerCase(className.charAt(0)) + className.substring(1);
+    }
+
+    /**
+     * 빈 이름으로 빈 인스턴스를 반환
+     */
     public <T> T genBean(String beanName) {
-        return null;
+        return (T) beans.get(beanName);
     }
 }


### PR DESCRIPTION
## 💡 @Configuration 및 @Bean 처리 로직

이번 수정의 핵심은 **`Reflections` 라이브러리**를 활용한 자동 빈 등록 로직에  
`@Configuration` 클래스와 그 안의 `@Bean` 메서드 처리 기능을 추가한 것입니다.

1. **설정 클래스 스캔**  
   `init()` 메서드에서  
```java
reflections.getTypesAnnotatedWith(Configuration.class)
```
를 사용하여 지정된 패키지 내의 모든 `@Configuration` 클래스를 찾습니다.  
예를 들어, `TestJacksonConfig` 같은 설정 클래스가 여기에 포함됩니다.

2. **@Bean 메서드 실행 및 의존성 주입**  
설정 클래스 인스턴스를 먼저 생성한 뒤,  
내부의 `@Bean` 어노테이션이 붙은 메서드를 실행합니다.  

* 메서드 이름을 빈 이름으로 사용하여 `beans`에 등록합니다.  
* 메서드 파라미터가 있다면, 해당 타입의 빈을 먼저 생성하여 주입합니다.  

예: 
```java
@Bean
public ObjectMapper testBaseObjectMapper(JavaTimeModule testBaseJavaTimeModule)
```
→ `JavaTimeModule` 빈이 먼저 생성되고, `ObjectMapper`에 주입됨

3. **생성 순서 보장**  
`@Configuration` → `@Bean` 빈 생성이 먼저 이루어진 뒤,  
`@Service`, `@Repository` 클래스들이 생성되도록 하여  
서비스/리포지토리에서 `@Bean` 빈을 안전하게 의존성으로 주입받을 수 있습니다.

이 구조 덕분에:
- 일반 POJO 객체도 빈으로 등록 가능 (`JavaTimeModule`, `ObjectMapper`)  
- 의존성 있는 `@Bean`끼리도 자동 주입 가능  
- 싱글톤 유지 및 중복 생성 방지  

결과적으로 테스트 케이스 `t7`, `t8`을 포함한 모든 테스트가 통과합니다.